### PR TITLE
Prevent infinite recursion by breaking on outer loop. All unit tests pass.

### DIFF
--- a/jael/lib/src/text/scanner.dart
+++ b/jael/lib/src/text/scanner.dart
@@ -174,7 +174,7 @@ class _Scanner implements Scanner {
   void scanHtml(bool asDSX) {
     var brackets = Queue<Token>();
 
-    do {
+    outer_loop:do {
       // Only continue if we find a left bracket
       if (true) {
         // || _scanner.matches('<') || _scanner.matches('{{')) {
@@ -192,7 +192,7 @@ class _Scanner implements Scanner {
 
           potential.sort((a, b) => b.span.length.compareTo(a.span.length));
 
-          if (potential.isEmpty) break;
+          if (potential.isEmpty) break outer_loop;
 
           var token = potential.first;
           tokens.add(token);

--- a/jael/test/text/scan_test.dart
+++ b/jael/test/text/scan_test.dart
@@ -4,6 +4,10 @@ import 'package:test/test.dart';
 import 'common.dart';
 
 main() {
+  test('handles forward slash before attribute', () {
+    scan('<img class=\\"mrfreeze\">', sourceUrl: 'test.jael').tokens;
+  });
+
   test('plain html', () {
     var tokens = scan('<img src="foo.png" />', sourceUrl: 'test.jael').tokens;
     tokens.forEach(print);


### PR DESCRIPTION
I added a unit test which fails (infinite loop) on current jael, but passes with this change.